### PR TITLE
Enable setting DNS options through global nerdctl config

### DIFF
--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -539,7 +539,7 @@ func createAction(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	netFlags, err := loadNetworkFlags(cmd)
+	netFlags, err := loadNetworkFlags(cmd, createOpt.GOptions)
 	if err != nil {
 		return fmt.Errorf("failed to load networking flags: %w", err)
 	}

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -376,7 +376,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 		return errors.New("flags -d and -a cannot be specified together")
 	}
 
-	netFlags, err := loadNetworkFlags(cmd)
+	netFlags, err := loadNetworkFlags(cmd, createOpt.GOptions)
 	if err != nil {
 		return fmt.Errorf("failed to load networking flags: %w", err)
 	}

--- a/cmd/nerdctl/helpers/cobra.go
+++ b/cmd/nerdctl/helpers/cobra.go
@@ -283,3 +283,10 @@ func AddPersistentBoolFlag(cmd *cobra.Command, name string, aliases, nonPersiste
 		}
 	}
 }
+
+// HiddenPersistentStringArrayFlag creates a persistent string slice flag and hides it.
+// Used mainly to pass global config values to individual commands.
+func HiddenPersistentStringArrayFlag(cmd *cobra.Command, name string, value []string, usage string) {
+	cmd.PersistentFlags().StringSlice(name, value, usage)
+	cmd.PersistentFlags().MarkHidden(name)
+}

--- a/cmd/nerdctl/helpers/flagutil.go
+++ b/cmd/nerdctl/helpers/flagutil.go
@@ -145,6 +145,18 @@ func ProcessRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error)
 	if err != nil {
 		return types.GlobalCommandOptions{}, err
 	}
+	dns, err := cmd.Flags().GetStringSlice("global-dns")
+	if err != nil {
+		return types.GlobalCommandOptions{}, err
+	}
+	dnsOpts, err := cmd.Flags().GetStringSlice("global-dns-opts")
+	if err != nil {
+		return types.GlobalCommandOptions{}, err
+	}
+	dnsSearch, err := cmd.Flags().GetStringSlice("global-dns-search")
+	if err != nil {
+		return types.GlobalCommandOptions{}, err
+	}
 
 	// Point to dataRoot for filesystem-helpers implementing rollback / backups.
 	err = pkg.InitFS(dataRoot)
@@ -169,6 +181,9 @@ func ProcessRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error)
 		BridgeIP:         bridgeIP,
 		KubeHideDupe:     kubeHideDupe,
 		CDISpecDirs:      cdiSpecDirs,
+		DNS:              dns,
+		DNSOpts:          dnsOpts,
+		DNSSearch:        dnsSearch,
 	}, nil
 }
 

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -188,6 +188,9 @@ func initRootCmdFlags(rootCmd *cobra.Command, tomlPath string) (*pflag.FlagSet, 
 	rootCmd.PersistentFlags().Bool("kube-hide-dupe", cfg.KubeHideDupe, "Deduplicate images for Kubernetes with namespace k8s.io")
 	rootCmd.PersistentFlags().StringSlice("cdi-spec-dirs", cfg.CDISpecDirs, "The directories to search for CDI spec files. Defaults to /etc/cdi,/var/run/cdi")
 	rootCmd.PersistentFlags().String("userns-remap", cfg.UsernsRemap, "Support idmapping for creating and running containers. This options is only supported on linux. If `host` is passed, no idmapping is done. if a user name is passed, it does idmapping based on the uidmap and gidmap ranges specified in /etc/subuid and /etc/subgid respectively")
+	helpers.HiddenPersistentStringArrayFlag(rootCmd, "global-dns", cfg.DNS, "Global DNS servers for containers")
+	helpers.HiddenPersistentStringArrayFlag(rootCmd, "global-dns-opts", cfg.DNSOpts, "Global DNS options for containers")
+	helpers.HiddenPersistentStringArrayFlag(rootCmd, "global-dns-search", cfg.DNSSearch, "Global DNS search domains for containers")
 	return aliasToBeInherited, nil
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,9 @@ cgroup_manager = "cgroupfs"
 hosts_dir      = ["/etc/containerd/certs.d", "/etc/docker/certs.d"]
 experimental   = true
 userns_remap   = ""
+dns            = ["8.8.8.8", "1.1.1.1"]
+dns_opts       = ["ndots:1", "timeout:2"]
+dns_search     = ["example.com", "example.org"]
 ```
 
 ## Properties
@@ -50,6 +53,9 @@ userns_remap   = ""
 | `kube_hide_dupe`    | `--kube-hide-dupe`                 |                           | Deduplicate images for Kubernetes with namespace k8s.io, no more redundant <none> ones are displayed    | Since 2.0.3      |
 | `cdi_spec_dirs`     | `--cdi-spec-dirs`                   |                          | The folders to use when searching for CDI ([container-device-interface](https://github.com/cncf-tags/container-device-interface)) specifications.    | Since 2.1.0 |
 | `userns_remap`      | `--userns-remap`                   |                           | Support idmapping of containers. This options is only supported on rootful linux. If `host` is passed, no idmapping is done. if a user name is passed, it does idmapping based on the uidmap and gidmap ranges specified in /etc/subuid and /etc/subgid respectively. |   Since 2.1.0 |
+| `dns`               | `--dns`                            |                           | Set custom DNS servers for container networking                                                                                                                  | Since 2.1.3 |
+| `dns_opts`          | `--dns-opt`                        |                           | Set DNS options for container networking                                                                                                                         | Since 2.1.3 |
+| `dns_search`        | `--dns-search`                     |                           | Set custom DNS search domains for container networking                                                                                                           | Since 2.1.3 |
 
 The properties are parsed in the following precedence:
 1. CLI flag

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,9 +41,11 @@ type Config struct {
 	HostGatewayIP    string   `toml:"host_gateway_ip"`
 	BridgeIP         string   `toml:"bridge_ip, omitempty"`
 	KubeHideDupe     bool     `toml:"kube_hide_dupe"`
-	// CDISpecDirs is a list of directories in which CDI specifications can be found.
-	CDISpecDirs []string `toml:"cdi_spec_dirs,omitempty"`
-	UsernsRemap string   `toml:"userns_remap, omitempty"`
+	CDISpecDirs      []string `toml:"cdi_spec_dirs,omitempty"` // CDISpecDirs is a list of directories in which CDI specifications can be found.
+	UsernsRemap      string   `toml:"userns_remap, omitempty"`
+	DNS              []string `toml:"dns,omitempty"`
+	DNSOpts          []string `toml:"dns_opts,omitempty"`
+	DNSSearch        []string `toml:"dns_search,omitempty"`
 }
 
 // New creates a default Config object statically,
@@ -66,5 +68,8 @@ func New() *Config {
 		KubeHideDupe:     false,
 		CDISpecDirs:      ncdefaults.CDISpecDirs(),
 		UsernsRemap:      "",
+		DNS:              []string{},
+		DNSOpts:          []string{},
+		DNSSearch:        []string{},
 	}
 }


### PR DESCRIPTION
This PR adds support for configuring DNS settings globally through the nerdctl configuration file (nerdctl.toml), allowing users to set default DNS servers, search domains, and options that apply to all containers unless explicitly overridden by command-line flags.

This is for a usecase where I want all  containers to use a specific dns server instead of system default. Currently, I have to use `--dns` flag with every container create/run commands. This functionality is available in docker which allows setting global dns config value in the daemon config file. 

#### Testing
Added a end to end test TestDNSWithGlobalConfig() that checks 4 scenarios:
  1. Global DNS settings used when no command-line options provided
  2. Command-line DNS options override global config (precedence test)
  3. Global DNS settings apply with host networking
  4. Global DNS settings apply with none networking